### PR TITLE
removed ill reference start_time in sdr.sdr.train()

### DIFF
--- a/sdr.py
+++ b/sdr.py
@@ -79,7 +79,9 @@ class sdr():
 			Alg.update_U()
 			if Alg.outer_converge(): break;
 
-		Alg.verify_result(start_time)
+		# the 'start_time' refers to the object in global namespace when run as
+		# __main__; cause problem when used as module
+		#Alg.verify_result(start_time)
 		
 	def get_projection_matrix(self):
 		return self.db['W']


### PR DESCRIPTION
The start_time reference in sdr.sdr.train() used by Alg.verify_result() actually refers to the object in global namespace when run as '__main__' module. As currently the verify_result() does nothing, it better be deleted.